### PR TITLE
Allow HTML output in post content

### DIFF
--- a/src/components/PostItem.js
+++ b/src/components/PostItem.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
-import Skeleton from 'react-loading-skeleton';
 
 import TagList from './TagList';
 

--- a/src/views/PostView.js
+++ b/src/views/PostView.js
@@ -81,7 +81,12 @@ export default class PostView extends React.Component {
                     </div>
 
                     <article className="post-view__content">
-                        <ReactMarkdown source={ post.content } renderers={{ code: CodeBlock }} plugins={ [ gfm ] } />
+                        <ReactMarkdown
+                            children={post.content}
+                            renderers={{ code: CodeBlock }}
+                            plugins={[gfm]}
+                            allowDangerousHtml={true}
+                        />
                     </article>
                 </div>
             </Fragment>


### PR DESCRIPTION
**Provide notes around what this PR achieves:**

Issue: #15 

Allows HTML to be output in content. This, unfortunately, has to set `allowDangerousHtml` so that markup in post content isn't ignored, but this shouldn't be an issue giving I'm the only one writing content.

**Provide any steps that may be required to test any new functionality:**

N/A

**If you have examples of this working, please demonstrate it:***

![image](https://user-images.githubusercontent.com/6696173/159120345-e41d663f-b133-4668-82c3-e375376bf4e3.png)
_A wild `sup` tag working..._

**Does this PR have any breaking changes?**

N/A
